### PR TITLE
Sort schema, table and indices lists by name.

### DIFF
--- a/lib/commands/queries.js
+++ b/lib/commands/queries.js
@@ -21,13 +21,14 @@
 				   FROM INFORMATION_SCHEMA.COLUMNS 
 				   WHERE TABLE_NAME = OBJECT_NAME(OBJECT_ID('%1$s')) AND 
 						  TABLE_SCHEMA = OBJECT_SCHEMA_NAME(OBJECT_ID('%1$s'))
-				   ORDER BY ORDINAL_POSITION;
+				   ORDER BY name;
 			***/}), table);
 		}
 
 		static listDatabasesSql() {
 			return mstring(function () {/***
-				SELECT name FROM sys.databases;
+				SELECT name FROM sys.databases
+				ORDER BY name;
 			***/});
 		}
 
@@ -37,7 +38,8 @@
 					TABLE_SCHEMA [schema], 
 					TABLE_NAME name, 
 					TABLE_TYPE type 
-				FROM INFORMATION_SCHEMA.TABLES;
+				FROM INFORMATION_SCHEMA.TABLES
+				ORDER BY name;
 			***/});
 		}
 
@@ -54,7 +56,8 @@
 							ORDER BY ic.key_ordinal
 							FOR XML PATH('')), 1, 1, '') columns
 				 FROM sys.indexes i 
-				 WHERE i.object_id=OBJECT_ID('%s');
+				 WHERE i.object_id=OBJECT_ID('%s')
+				 ORDER BY i.name;
 			***/}), table);
 		}
 


### PR DESCRIPTION
I find it frustrating when looking at list of tables, schema or indices, and they are not sorted alphabetically. I always (99.99% of the time) end up having to slowly scan the list to find what I'm looking for. Therefore I think it makes more sense to sort these lists. 

Hope you feel the same way. :)

Cheers,
Diego
