### PR TITLE
added -D option to allow for old style connection strings

### DIFF
--- a/README.md
+++ b/README.md
@@ -36,6 +36,7 @@ Options:
   -p, --pass <pass>              Password to use for authentication
   -o, --port <port>              Port to connect to
   -t, --timeout <timeout>        Connection timeout in ms
+  -D, --dsn <old style dsn>      Classic DSN connection string
   -d, --database <database>      Database to connect to
   -q, --query <query>            The query to execute
   -v, --tdsVersion <tdsVersion>  Version of tds protocol to use [7_4, 7_2, 7_3_A, 7_3_B, 7_4]
@@ -46,6 +47,13 @@ Options:
 To connect to a SQL Server instance in Azure invoke mssql as follows
 ```bash
 mssql -s abcdef.database.windows.net -u username@abcdef -p thepassword -d mydatabase -e
+```
+
+A classic style DSN connection string may be used in lieu of all other
+options
+
+``` bash
+mssql -D "Server=localhost,1433;UID=DOMAIN\\user;PWD=password"
 ```
 
 You will get a prompt as follows:

--- a/lib/options.js
+++ b/lib/options.js
@@ -27,6 +27,7 @@
                     .option('-o, --port <port>', 'Port to connect to')
                     .option('-t, --timeout <timeout>', 'Connection timeout in ms')
                     .option('-T, --requestTimeout <timeout>', 'Request timeout in ms')
+                    .option('-D, --dsn <old-style dsn>', 'DSN connection string')
                     .option('-d, --database <database>', 'Database to connect to')
                     .option('-q, --query <query>', 'The query to execute')
                     .option('-v, --tdsVersion <tdsVersion>', 'Version of tds protocol to use [7_4, 7_2, 7_3_A, 7_3_B, 7_4]')
@@ -39,7 +40,7 @@
                 this.env = env;
                 this.args = {};
                 _.extend(this.args, _.pick(program, 'server', 'user', 'pass',
-                    'port', 'requestTimeout', 'timeout',
+                    'port', 'requestTimeout', 'timeout', 'dsn',
                     'database', 'query', 'tdsVersion',
                     'encrypt', 'format', 'config'));
 
@@ -74,6 +75,7 @@
                 user: env.SQLCLI_USER || 'sa',
                 pass: env.SQLCLI_PASSWORD,
                 server: env.SQLCLI_SERVER || 'localhost',
+                dsn: env.SQLCLI_DSN,
                 database: env.SQLCLI_DATABASE,
                 port: env.SQLCLI_PORT,
                 timeout: env.SQLCLI_TIMEOUT,
@@ -84,7 +86,8 @@
 
             config = _.extend({}, defaults, config, args);
 
-            var connectInfo = {
+            var connectInfo = !config.dsn 
+              ? {
                 user: config.user,
                 password: config.pass,
                 server: config.server,
@@ -100,7 +103,8 @@
                     max: 1,
                     min: 1
                 }
-            };
+              }
+          : config.dsn ;
 
             return connectInfo;
         }


### PR DESCRIPTION
Hi!  I like your client but need Windows domain authentication to connect in my environment.  I've hacked in a (working! and ugly!) option to allow classic style DSN strings on the command line (at the expense of ignoring all the other options).  I'm sending along my changes but understand this is maybe not the direction you want to go.  Thanks!